### PR TITLE
Improve unlock button for receiving OrderArticles manually adjusted

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -51,7 +51,8 @@ body {
 
 // Do not use additional margin for input in table
 .form-horizontal .control-group.control-group-intable,
-.form-horizontal .controls.controls-intable {
+.form-horizontal .controls.controls-intable,
+.input-prepend.intable {
   margin: 0;
 }
 

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -46,10 +46,20 @@ module OrdersHelper
   def receive_input_field(form)
     order_article = form.object
     units_expected = (order_article.units_billed or order_article.units_to_order)
-    form.text_field :units_received, class: 'input-nano package units_received',
+    
+    input_html = ''
+    if order_article.result_manually_changed?
+      input_html += '<span class="input-prepend intable">' +
+        button_tag(nil, type: :button, class: 'btn unlocker', title: t('.locked_to_protect_unlock_button')) {'<i class="icon icon-unlock"></i>'.html_safe}
+    end
+    
+    input_html += form.text_field :units_received, class: 'input input-nano package units_received',
       data: {'units-expected' => units_expected},
       disabled: order_article.result_manually_changed?,
       title: order_article.result_manually_changed? ? t('.locked_to_protect_manual_update') : nil,
       autocomplete: 'off'
+    
+    input_html += '</span>' if order_article.result_manually_changed?
+    input_html.html_safe
   end
 end

--- a/app/views/orders/_edit_amount.html.haml
+++ b/app/views/orders/_edit_amount.html.haml
@@ -25,6 +25,3 @@
     %td.units_delta
     %td
       = link_to t('ui.edit'), edit_order_order_article_path(order_article.order, order_article), remote: true, class: 'btn btn-small'
-      - if order_article.result_manually_changed?
-        = button_tag nil, class: 'btn btn-small unlocker', title: t('.locked_to_protect_unlock_button') do
-          %i.icon-unlock

--- a/app/views/orders/_edit_amounts.html.haml
+++ b/app/views/orders/_edit_amounts.html.haml
@@ -62,8 +62,8 @@
     }
     
     function unlock_receive_input_field() {
-      $('.units_received', $(this).closest('tr')).prop('disabled', false);
-      $(this).remove();
+      $('.units_received', $(this).closest('tr')).prop('disabled', false).focus();
+      $(this).replaceWith('<i class="icon icon-warning-sign add-on"></i>');
     }
 
 %table#order_articles.ordered-articles.table.table-striped.stupidtable


### PR DESCRIPTION
This prepends the unlock button to the receive input. Advantages:
- state of the button is kept after AJAX update of the `OrderArticle`
- user finds the button for unlocking next to the input
- button is replaced by a warning sign indicating the override
